### PR TITLE
Kubernetes preparation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build/
 tests/
 *.so
+projects

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
     rm ~/miniconda.sh && \
 #Python Dependencies
 #For some reason, pip works for h5py and pandas, and conda doesn't
-    pip --no-cache-dir install h5py pandas cloud-volume python-igraph future && \
+    pip --no-cache-dir install h5py pandas cloud-volume task-queue python-igraph future && \
     pip --no-cache-dir install requests psycopg2-binary && \
     conda install scipy pybind11 sqlalchemy && \
     conda install pytorch==1.0.1 torchvision cudatoolkit=10.0 -c pytorch && \
@@ -35,4 +35,3 @@ RUN apt-get update && \
 
 
 WORKDIR /Synaptor/tasks
-ENTRYPOINT ["bash","dispatcher.sh"]

--- a/docker/deploy-cpu.yaml
+++ b/docker/deploy-cpu.yaml
@@ -25,7 +25,7 @@ spec:
         name: synaptor-cpu
         imagePullPolicy: Always
         command: ["/bin/sh"]
-        args: ["-c", "python worker.py --qurl https://sqs.us-east-1.amazonaws.com/DIGITS/QUEUE_NAME --lease_seconds 20"]
+        args: ["-c", "python worker.py https://sqs.us-east-1.amazonaws.com/DIGITS/QUEUE_NAME 20"]
         resources: 
           requests:
             cpu: 3
@@ -33,7 +33,7 @@ spec:
         - name: secrets
           mountPath: /root/.cloudvolume/secrets
           readOnly: true
-        - name: proc_url
+        - name: storagestr
           mountPath: /root/proc_url
           readOnly: true
         - name: boto
@@ -44,7 +44,7 @@ spec:
       - name: secrets
         secret:
           secretName: secrets
-      - name: proc_url
+      - name: storagestr
         secret:
           secretName: proc_url
       - name: boto

--- a/docker/deploy-cpu.yaml
+++ b/docker/deploy-cpu.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    run: synaptor-cpu
+  name: synaptor-cpu
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: synaptor-cpu
+  strategy:
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 100%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: synaptor-cpu
+    spec:
+      containers:
+      - image: seunglab/synaptor:latest
+        name: synaptor-cpu
+        imagePullPolicy: Always
+        command: ["/bin/sh"]
+        args: ["-c", "python worker.py --qurl https://sqs.us-east-1.amazonaws.com/DIGITS/QUEUE_NAME --lease_seconds 20"]
+        resources: 
+          requests:
+            cpu: 3
+        volumeMounts:
+        - name: secrets
+          mountPath: /root/.cloudvolume/secrets
+          readOnly: true
+        - name: proc_url
+          mountPath: /root/proc_url
+          readOnly: true
+        - name: boto
+          mountPath: /root/.boto
+          readOnly: true
+      dnsPolicy: Default
+      volumes:
+      - name: secrets
+        secret:
+          secretName: secrets
+      - name: proc_url
+        secret:
+          secretName: proc_url
+      - name: boto
+        secret:
+          secretName: boto

--- a/docker/deploy-gpu.yaml
+++ b/docker/deploy-gpu.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    run: synaptor-gpu
+  name: synaptor-gpu
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: synaptor-gpu
+  strategy:
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 100%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: synaptor-gpu
+    spec:
+      containers:
+      - image: seunglab/synaptor:latest
+        name: synaptor-gpu
+        imagePullPolicy: Always
+        command: ["/bin/sh"]
+        args: ["-c", "python worker.py --qurl https://sqs.us-east-1.amazonaws.com/DIGITS/QUEUE_NAME --lease_seconds 20"]
+        resources: 
+          limits:
+            nvidia.com/gpu: 1
+        volumeMounts:
+        - name: secrets
+          mountPath: /root/.cloudvolume/secrets
+          readOnly: true
+        - name: proc_url
+          mountPath: /root/proc_url
+          readOnly: true
+        - name: boto
+          mountPath: /root/.boto
+          readOnly: true
+      dnsPolicy: Default
+      volumes:
+      - name: secrets
+        secret:
+          secretName: secrets
+      - name: proc_url
+        secret:
+          secretName: proc_url
+      - name: boto
+        secret:
+          secretName: boto

--- a/docker/deploy-gpu.yaml
+++ b/docker/deploy-gpu.yaml
@@ -25,7 +25,7 @@ spec:
         name: synaptor-gpu
         imagePullPolicy: Always
         command: ["/bin/sh"]
-        args: ["-c", "python worker.py --qurl https://sqs.us-east-1.amazonaws.com/DIGITS/QUEUE_NAME --lease_seconds 20"]
+        args: ["-c", "python worker.py https://sqs.us-east-1.amazonaws.com/DIGITS/QUEUE_NAME 20"]
         resources: 
           limits:
             nvidia.com/gpu: 1
@@ -33,7 +33,7 @@ spec:
         - name: secrets
           mountPath: /root/.cloudvolume/secrets
           readOnly: true
-        - name: proc_url
+        - name: storagestr
           mountPath: /root/proc_url
           readOnly: true
         - name: boto
@@ -44,7 +44,7 @@ spec:
       - name: secrets
         secret:
           secretName: secrets
-      - name: proc_url
+      - name: storagestr
         secret:
           secretName: proc_url
       - name: boto

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ python-igraph
 pandas
 h5py
 cloud-volume
+task-queue
 pytorch==0.4.0
 torchvision
 future

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,0 +1,33 @@
+import shlex
+import subprocess
+
+from taskqueue import RegisteredTask, TaskQueue
+
+class SynaptorTask(RegisteredTask):
+    def __init__(self, command_line=""):
+        super().__init__(command_line)
+        self.cmd = [shlex.quote(x) for x in shlex.split(command_line)]
+
+    def execute(self):
+        # Interim solution: Forward the command to the dispatcher.sh, which
+        # will then again call the correct python scripts to run... ideally,
+        # we would start the Python functions directly from here.
+        def run_cmd(cmd):
+            popen = subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, universal_newlines=True
+            )
+            # Doing this so we can keep track of each individual tasks output
+            for stdout_line in iter(popen.stdout.readline, ""):
+                yield stdout_line
+            popen.stdout.close()
+            return_code = popen.wait()
+            if return_code:
+                raise subprocess.CalledProcessError(return_code, cmd)
+
+        if self.cmd:
+            for stdout in run_cmd(["./dispatcher.sh", *self.cmd]):
+                print(stdout, end="")
+                if "invalid task name" in stdout:
+                    raise TypeError(stdout)
+        else:
+            raise ValueError("No command received")

--- a/tasks/dispatcher.sh
+++ b/tasks/dispatcher.sh
@@ -16,5 +16,6 @@ case $1 in
     create_index)     python3 create_index.py ${@:2} ;;
     dedup_chunk_segs) python3 dedup_chunk_segs.py ${@:2} ;;
     init_db)          python3 init_db.py ${@:2} ;;
+    hello_world)      python3 hello_world.py ${@:2} ;;
     *)  echo "invalid task name $1"
 esac

--- a/tasks/hello_world.py
+++ b/tasks/hello_world.py
@@ -1,0 +1,13 @@
+import argparse
+from time import sleep
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument("proc_url")
+parser.add_argument("message")
+parser.add_argument("sleep", type=float, default=0.0)
+
+args = parser.parse_args()
+print("Sleeping for {} s".format(args.sleep), flush=True)
+sleep(args.sleep)
+print("Hello world: {}".format(args.message), flush=True)

--- a/tasks/hello_world.py
+++ b/tasks/hello_world.py
@@ -1,0 +1,12 @@
+import argparse
+from time import sleep
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument("message", type=str)
+parser.add_argument("sleep", type=float, default=0.0)
+
+args = parser.parse_args()
+print("Sleeping for {} s".format(args.sleep), flush=True)
+sleep(args.sleep)
+print("Hello world: {}".format(args.message), flush=True)

--- a/tasks/task_creation.py
+++ b/tasks/task_creation.py
@@ -1,0 +1,106 @@
+import copy
+import math
+import os
+import subprocess
+
+from time import strftime
+
+from cloudvolume import CloudVolume
+from cloudvolume.lib import Bbox, Vec, xyzrange, min2, yellow
+from taskqueue import GreenTaskQueue
+
+from tasks import SynaptorTask
+
+try:
+  OPERATOR_CONTACT = subprocess.check_output("git config user.email", shell=True)
+  OPERATOR_CONTACT = str(OPERATOR_CONTACT.rstrip())
+except:
+  try:
+    print(yellow('Unable to determine provenance contact email. Set "git config user.email". Using unix $USER instead.'))
+    OPERATOR_CONTACT = os.environ['USER']
+  except:
+    print(yellow('$USER was not set. The "owner" field of the provenance file will be blank.'))
+    OPERATOR_CONTACT = ''
+
+def tup2str(t): 
+  return " ".join(map(str, t))
+
+def create_connected_component_tasks(
+    outpath, cleftpath, proc_url, proc_dir,
+    cc_thresh, sz_thresh, bounds, shape, 
+    mip=0, parallel=1, hashmax=1
+  ):
+  
+  shape = Vec(*shape)
+  mip = int(mip)
+
+  vol = CloudVolume(cleftpath, mip=mip)
+  bounds = vol.bbox_to_mip(bounds, mip=0, to_mip=mip)
+  bounds = Bbox.clamp(bounds, vol.bounds)
+  
+  class ConnectedComponentsTaskIterator(object):
+    def __init__(self, level_start, level_end):
+      self.level_start = level_start
+      self.level_end = level_end
+    def __len__(self):
+      return self.level_end - self.level_start
+    def __getitem__(self, slc):
+      itr = copy.deepcopy(self)
+      itr.level_start = self.level_start + slc.start 
+      itr.level_end = self.level_start + slc.stop
+      return itr
+    def __iter__(self):
+      self.bounds = bounds.clone()
+      self.bounds.minpt.z = bounds.minpt.z + self.level_start * shape.z
+      self.bounds.maxpt.z = bounds.minpt.z + self.level_end * shape.z
+
+      for startpt in xyzrange( self.bounds.minpt, self.bounds.maxpt, shape ):
+        task_shape = min2(shape.clone(), self.bounds.maxpt - startpt)
+
+        task_bounds = Bbox( startpt, startpt + task_shape )
+        if task_bounds.volume() < 1:
+          continue
+
+        chunk_begin = tup2str(task_bounds.minpt)
+        chunk_end = tup2str(task_bounds.maxpt)
+
+        cmd = f"""
+          chunk_ccs {outpath} {cleftpath} {proc_url} \
+            {cc_thresh} {sz_thresh} \
+            --chunk_begin {chunk_begin} --chunk_end {chunk_end} --mip {mip} \
+            --proc_dir {proc_dir} --hashmax {hashmax} \
+            --parallel {parallel} 
+          """.strip()
+
+        yield SynaptorTask(cmd)
+
+      job_details = {
+        'method': {
+          'task': 'ConnectedComponentsTask',
+          'outpath': outpath,
+          'cleftpath': cleftpath,
+          'proc_url': proc_url,
+          'proc_dir': proc_dir,
+          'cc_thresh': cc_thresh,
+          'sz_thresh': sz_thresh,
+          'parallel': parallel,
+          'hashmax': hashmax,
+          'shape': list(map(int, shape)),
+          'bounds': [
+            bounds.minpt.tolist(),
+            bounds.maxpt.tolist()
+          ],
+          'mip': mip,
+        },
+        'by': OPERATOR_CONTACT,
+        'date': strftime('%Y-%m-%d %H:%M %Z'),
+      }
+
+      dvol = CloudVolume(outpath)
+      dvol.provenance.sources = [ cleftpath ]
+      dvol.provenance.processing.append(job_details) 
+      dvol.commit_provenance()
+  
+  level_end = int(math.ceil(bounds.size3().z / shape.z)) + 1
+  return ConnectedComponentsTaskIterator(0, level_end)
+

--- a/tasks/worker.py
+++ b/tasks/worker.py
@@ -1,0 +1,45 @@
+import argparse
+import shlex
+import subprocess
+
+from taskqueue import RegisteredTask, TaskQueue
+
+
+class SynaptorTask(RegisteredTask):
+    def __init__(self, command_line=""):
+        super().__init__(command_line)
+        self.cmd = [shlex.quote(x) for x in shlex.split(command_line)]
+
+    def execute(self):
+        # Interim solution: Forward the command to the dispatcher.sh, which
+        # will then again call the correct python scripts to run... ideally,
+        # we would start the Python functions directly from here.
+        def run_cmd(cmd):
+            popen = subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, universal_newlines=True
+            )
+            # Doing this so we can keep track of each individual tasks output
+            for stdout_line in iter(popen.stdout.readline, ""):
+                yield stdout_line
+            popen.stdout.close()
+            return_code = popen.wait()
+            if return_code:
+                raise subprocess.CalledProcessError(return_code, cmd)
+
+        if self.cmd:
+            for stdout in run_cmd(["./dispatcher.sh", *self.cmd]):
+                print(stdout, end="")
+                if "invalid task name" in stdout:
+                    raise TypeError(stdout)
+        else:
+            raise ValueError("No command received")
+
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument("qurl", type=str)
+parser.add_argument("lease_seconds", type=int, default=300)
+
+args = parser.parse_args()
+with TaskQueue(qurl=args.qurl, queue_server="sqs", n_threads=0) as tq:
+    tq.poll(lease_seconds=args.lease_seconds)

--- a/tasks/worker.py
+++ b/tasks/worker.py
@@ -1,0 +1,45 @@
+import argparse
+import shlex
+import subprocess
+
+from taskqueue import RegisteredTask, TaskQueue
+
+
+class SynaptorTask(RegisteredTask):
+    def __init__(self, command_line=""):
+        super().__init__(command_line)
+        self.cmd = shlex.split(command_line)
+
+    def execute(self):
+        # Interim solution: Forward the command to the dispatcher.sh, which
+        # will then again call the correct python scripts to run... ideally,
+        # we would start the Python functions directly from here.
+        def run_cmd(cmd):
+            popen = subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, universal_newlines=True
+            )
+            # Doing this so we can keep track of each individual tasks output
+            for stdout_line in iter(popen.stdout.readline, ""):
+                yield stdout_line
+            popen.stdout.close()
+            return_code = popen.wait()
+            if return_code:
+                raise subprocess.CalledProcessError(return_code, cmd)
+
+        if self.cmd:
+            for stdout in run_cmd(["./dispatcher.sh", *self.cmd]):
+                print(stdout, end="")
+                if "invalid task name" in stdout:
+                    raise TypeError(stdout)
+        else:
+            raise ValueError("No command received")
+
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument("qurl", type=str)
+parser.add_argument("lease_seconds", type=int, default=300)
+
+args = parser.parse_args()
+with TaskQueue(qurl=args.qurl, queue_server="sqs", n_threads=0) as tq:
+    tq.poll(lease_seconds=args.lease_seconds)

--- a/tasks/worker.py
+++ b/tasks/worker.py
@@ -1,39 +1,6 @@
 import argparse
-import shlex
-import subprocess
 
-from taskqueue import RegisteredTask, TaskQueue
-
-
-class SynaptorTask(RegisteredTask):
-    def __init__(self, command_line=""):
-        super().__init__(command_line)
-        self.cmd = [shlex.quote(x) for x in shlex.split(command_line)]
-
-    def execute(self):
-        # Interim solution: Forward the command to the dispatcher.sh, which
-        # will then again call the correct python scripts to run... ideally,
-        # we would start the Python functions directly from here.
-        def run_cmd(cmd):
-            popen = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, universal_newlines=True
-            )
-            # Doing this so we can keep track of each individual tasks output
-            for stdout_line in iter(popen.stdout.readline, ""):
-                yield stdout_line
-            popen.stdout.close()
-            return_code = popen.wait()
-            if return_code:
-                raise subprocess.CalledProcessError(return_code, cmd)
-
-        if self.cmd:
-            for stdout in run_cmd(["./dispatcher.sh", *self.cmd]):
-                print(stdout, end="")
-                if "invalid task name" in stdout:
-                    raise TypeError(stdout)
-        else:
-            raise ValueError("No command received")
-
+import synaptor.tasks # triggers registration of SynaptorTask
 
 parser = argparse.ArgumentParser()
 


### PR DESCRIPTION
* Add HelloWorld task (to test the TaskQueue polling)
* Add Kubernetes deployment templates
* Add python-task-queue dependencies + worker script
  * keeps polling task strings from your task queue and simply passes the arguments to the old `dispatcher.sh`
  * Known issue: Doesn't like arguments with whitespaces
* Removed entrypoint from Docker - will be called from K8s deployment file with two parameters: `queue_name` and `lease_seconds`.
